### PR TITLE
Pin format compatibility

### DIFF
--- a/src/bin.cpp
+++ b/src/bin.cpp
@@ -59,7 +59,7 @@ void comment_on_signature(const GpgME::Signature& sig) {
 
 std::string Bin::code_from_dpaste_uri(const std::string& uri) {
     const auto p = uri.find_first_of(DPASTE_URI_PREFIX);
-    return uri.substr(p != std::string::npos ? sizeof(DPASTE_URI_PREFIX)-1 : p);
+    return uri.substr(p != std::string::npos ? sizeof(DPASTE_URI_PREFIX)-1 : 0);
 }
 
 int Bin::get(std::string&& code, bool no_decrypt) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,10 @@
 
 #include <memory>
 #include <string>
+
+extern "C" {
 #include <getopt.h>
+}
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
Passing a PIN without the `dpaste:` prefix would crash the program. This fixes the issue.

Additionally, `getopt` header include has been wrapped into `extern` instruction.