### PR TITLE
Multiple cipher support: GPG, AES

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ OpenPGP protocol (a working gpg configuration needs to be found on the system).
 ## How to build
 
 Assuming you have the installed the project dependencies prior to this, you can
-either use CMake or GNU Autotools to build.
+either use CMake or GNU Autotools to build. A `c++17` compliant compiler is
+required to compile the program.
 
 ### Using GNU Autotools
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,34 @@ retrieve the pasted file within 10 minutes by simply doing:
 $ dpaste -g dpaste:74236E62
 ```
 
-Use respectively options `-e` and `-s` to encrypt and sign messages using the
-OpenPGP protocol (a working gpg configuration needs to be found on the system).
+## Encryption
+
+One can encrypt his document using the option `--aes-encrypt` or
+`--gpg-encrypt -r {recipient}`. In the former case, AES-CBC is used and in
+the latter it is simple GPG encryption. One can also *sign-then-encrypt* his
+message by adding the flag `-s` (a working gpg configuration needs to be found
+on the system). If both `--aes-encrypt` and `--gpg-encrypt` (or `-s`) options
+are present, aes encryption method is used.
+
+### AES
+
+When using `--aes-encrypt`, `dpaste` will generate a random 32-bit passphrase
+which will then be stretched using [argon2][] crypto library. This is all
+handled by OpenDHT crypto layer. After pasting the blob, the returned PIN will
+be 64 bits long instead of the classic 32 bits. Indeed, the generated 32-bit
+password is appended to the location code used to index on the DHT. For e.g.:
+
+```sh
+$ dpaste --aes-encrypt < ${some_file}
+DPASTE: Encrypting (aes-cbc) data...
+DPASTE: Pasting data...
+dpaste:B79F2F91C811D5DC
+```
+
+Therefore, the blob will be pasted on `HASH("B79F2F91")` and encrypted with
+a key derived from the passphrase `C811D5DC`.
+
+[argon2]: https://github.com/P-H-C/phc-winner-argon2
 
 ## How to build
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ not likely to be "down".
 
 ## Roadmap
 
-- Password based encryption (AES using gnutls);
 - Add support for values with size greater than 64Ko (splitting values across
   multiple locations);
+- ~~Password based encryption (AES using gnutls)~~;
 - ~~Add user configuration file system;~~
 - ~~Support RSA encrypt/sign using user's GPG key;~~
 - ~~Support running the DHT node as service for executing dpaste operations.~~

--- a/configure.ac
+++ b/configure.ac
@@ -13,9 +13,9 @@ AS_IF([test "x$enable_debug" = "xyes"],
 AC_PROG_CXX
 AC_PROG_RANLIB
 
-AX_CXX_COMPILE_STDCXX(14,[noext],[mandatory])
+AX_CXX_COMPILE_STDCXX(17,[noext],[mandatory])
 # explicit c++14 in flags so that compile_commands.json yields it.
-CXXFLAGS="${CXXFLAGS} -std=c++14"
+CXXFLAGS="${CXXFLAGS} -std=c++17"
 
 PKG_CHECK_MODULES([OpenDHT], [opendht >= 1.2])
 PKG_CHECK_MODULES([CURLPP], [curlpp])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,7 @@ libdpaste_a_SOURCES = \
 					  http_client.cpp \
 					  bin.cpp \
 					  log.cpp \
+					  cipher.cpp \
 					  gpgcrypto.cpp
 dpaste_SOURCES = main.cpp
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,8 @@ libdpaste_a_SOURCES = \
 					  bin.cpp \
 					  log.cpp \
 					  cipher.cpp \
-					  gpgcrypto.cpp
+					  gpgcrypto.cpp \
+					  aescrypto.cpp
 dpaste_SOURCES = main.cpp
 
 # Variables defined in toplevel Makefile. Thus, `make` cannot be called from

--- a/src/aescrypto.cpp
+++ b/src/aescrypto.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 Simon Désaulniers
+ * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
+ *
+ * This file is part of dpaste.
+ *
+ * dpaste is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dpaste is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opendht/crypto.h>
+
+#include "log.h"
+#include "aescrypto.h"
+
+namespace dpaste {
+namespace crypto {
+
+std::string AES::getPassword(const std::shared_ptr<Parameters>& params) const {
+    if (auto p = std::get_if<AESParameters>(params.get()))
+        return p->password;
+    return {};
+}
+
+std::vector<uint8_t> AES::processPlainText(std::vector<uint8_t> plain_text, std::shared_ptr<Parameters>&& params) {
+    DPASTE_MSG("Encrypting (aes-cbc) data...");
+    return dht::crypto::aesEncrypt(plain_text, getPassword(params));
+}
+
+std::vector<uint8_t> AES::processCipherText(std::vector<uint8_t> cipher_text, std::shared_ptr<Parameters>&& params) {
+    DPASTE_MSG("Decrypting (aes-cbc)...");
+    return dht::crypto::aesDecrypt(cipher_text, getPassword(params));
+}
+
+} /* crypto */
+} /* dpaste */
+
+/* vim:set et sw=4 ts=4 tw=120: */
+

--- a/src/aescrypto.h
+++ b/src/aescrypto.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 Simon Désaulniers
+ * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
+ *
+ * This file is part of dpaste.
+ *
+ * dpaste is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dpaste is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "cipher.h"
+
+namespace dpaste {
+namespace crypto {
+
+class AES : public Cipher {
+public:
+    /**
+     * Length of the PIN if it contains the password for encrypted pasted data.
+     * It consists of 16 hexadecimal characters: 16*4 = 64 bits. Last 32 bits
+     * encode the password. Otherwise, PIN should be 32 bits.
+     */
+    static const constexpr size_t PIN_WITH_PASS_LEN {16};
+    /**
+     * Number of bytes offsetting the password in the binary representation of
+     * the hexadecimal password.
+     */
+    static const constexpr size_t CODE_PASS_OFFSET {4};
+
+    AES() {}
+    virtual ~AES () {}
+
+    std::vector<uint8_t>
+        processPlainText(std::vector<uint8_t> plain_text, std::shared_ptr<Parameters>&& params) override;
+    std::vector<uint8_t>
+        processCipherText(std::vector<uint8_t> cipher_text, std::shared_ptr<Parameters>&& params) override;
+private:
+    std::string getPassword(const std::shared_ptr<Parameters>& params) const;
+};
+
+} /* crypto */
+} /* dpaste */
+
+/* vim:set et sw=4 ts=4 tw=120: */
+

--- a/src/bin.cpp
+++ b/src/bin.cpp
@@ -74,7 +74,6 @@ std::pair<bool, std::string> Bin::get(std::string&& code, bool no_decrypt) {
         auto values = node.get(lcode);
         if (not values.empty())
             data = values.front();
-        node.stop();
     }
 
     if (not data.empty()) {
@@ -136,8 +135,7 @@ std::string Bin::random_pin() {
     return pin_s;
 }
 
-std::string Bin::paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params) const
-{
+std::string Bin::paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params) {
     /* paste a blob on the DHT */
     auto code = random_pin();
     std::string pwd = "";
@@ -180,13 +178,8 @@ std::string Bin::paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Para
     DPASTE_MSG("Pasting data...");
     auto bin_packet = p.serialize();
     auto success = http_client_->put(code, {bin_packet.begin(), bin_packet.end()});
-    if (not success) {
-        Node node;
-        node.run();
-
+    if (not success)
         success = node.paste(code, std::move(bin_packet));
-        node.stop();
-    }
 
     return success ? DPASTE_URI_PREFIX+code+pwd  : "";
 }

--- a/src/bin.h
+++ b/src/bin.h
@@ -30,7 +30,7 @@
 #include "config.h"
 #include "node.h"
 #include "http_client.h"
-#include "gpgcrypto.h"
+#include "cipher.h"
 
 namespace dpaste {
 #ifdef DPASTE_TEST
@@ -61,26 +61,15 @@ public:
     /**
      * Execute procedure to publish content and generate the associated code.
      *
-     * @param data            Data to be pasted.
-     * @param recipient       The recipient of the pasted data.
-     * @param sign            Whether to sign the data or not.
-     * @param self_recipient  Whether including self in recipient list.
+     * @param data    Data to be pasted.
+     * @param params  Cryptographic parameters.
      *
      * @return the code (key) to the pasted data. If empty, then process failed.
      */
-    std::string paste(std::vector<uint8_t>&& data,
-            std::string&& recipient={},
-            bool sign=false,
-            bool self_recipient=false) const;
-    std::string paste(std::stringstream&& input_stream,
-            std::string&& recipient={},
-            bool sign=false,
-            bool self_recipient=false) const
-    {
+    std::string paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params) const;
+    std::string paste(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>&& params) const {
         return paste(data_from_stream(std::move(input_stream)),
-                std::forward<std::string>(recipient),
-                sign,
-                self_recipient);
+                std::forward<std::unique_ptr<crypto::Parameters>>(params));
     }
 
 private:
@@ -116,13 +105,10 @@ private:
 
     static std::string random_pin();
 
-    /* crypto */
-    std::unique_ptr<GPGCrypto> gpg {};
-    std::string keyid_ {};
+    std::map<std::string, std::string> conf_;
 
     /* transport */
     std::unique_ptr<HttpClient> http_client_ {};
-    std::map<std::string, std::string> conf;
     Node node {};
 };
 

--- a/src/bin.h
+++ b/src/bin.h
@@ -67,8 +67,8 @@ public:
      *
      * @return the code (key) to the pasted data. If empty, then process failed.
      */
-    std::string paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params) const;
-    std::string paste(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>&& params) const {
+    std::string paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params);
+    std::string paste(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>&& params) {
         return paste(data_from_stream(std::move(input_stream)),
                 std::forward<std::unique_ptr<crypto::Parameters>>(params));
     }

--- a/src/bin.h
+++ b/src/bin.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <memory>
 #include <map>
+#include <utility>
 
 #include "config.h"
 #include "node.h"

--- a/src/cipher.cpp
+++ b/src/cipher.cpp
@@ -20,6 +20,7 @@
 
 #include "cipher.h"
 #include "gpgcrypto.h"
+#include "aescrypto.h"
 
 namespace dpaste {
 namespace crypto {
@@ -33,22 +34,23 @@ void Cipher::init() {
     initialized = true;
 }
 
-std::shared_ptr<Cipher> Cipher::get(const std::vector<uint8_t>& cipher_text) {
-
-    if (GPG::isGPGencrypted(cipher_text)) {
+std::shared_ptr<Cipher> Cipher::get(const std::vector<uint8_t>& cipher_text, const std::string& pin="") {
+    if (GPG::isGPGencrypted(cipher_text))
         return std::make_shared<GPG>();
-    }
+    else if (pin.size() == AES::PIN_WITH_PASS_LEN)
+        return std::make_shared<AES>();
     return {};
 }
 
 std::shared_ptr<Cipher> Cipher::get(Scheme scheme, std::shared_ptr<Parameters>&& params) {
     switch (scheme) {
+        case Scheme::AES:
+            return std::make_shared<AES>();
         case Scheme::GPG:
             if (auto gpg_params = std::get_if<GPGParameters>(params.get()))
                 return std::static_pointer_cast<Cipher>(std::make_shared<GPG>(gpg_params->key_id));
             else
                 return std::make_shared<GPG>();
-            break;
         default:
             break;
     }

--- a/src/cipher.cpp
+++ b/src/cipher.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 Simon Désaulniers
+ * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
+ *
+ * This file is part of dpaste.
+ *
+ * dpaste is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dpaste is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cipher.h"
+#include "gpgcrypto.h"
+
+namespace dpaste {
+namespace crypto {
+
+void Cipher::init() {
+    static bool initialized = false;
+    if (initialized) return;
+
+    GPG::init();
+
+    initialized = true;
+}
+
+std::shared_ptr<Cipher> Cipher::get(const std::vector<uint8_t>& cipher_text) {
+
+    if (GPG::isGPGencrypted(cipher_text)) {
+        return std::make_shared<GPG>();
+    }
+    return {};
+}
+
+std::shared_ptr<Cipher> Cipher::get(Scheme scheme, std::shared_ptr<Parameters>&& params) {
+    switch (scheme) {
+        case Scheme::GPG:
+            if (auto gpg_params = std::get_if<GPGParameters>(params.get()))
+                return std::static_pointer_cast<Cipher>(std::make_shared<GPG>(gpg_params->key_id));
+            else
+                return std::make_shared<GPG>();
+            break;
+        default:
+            break;
+    }
+    return {};
+}
+
+} /* crypto */
+} /* dpaste */
+
+/* vim:set et sw=4 ts=4 tw=120: */
+

--- a/src/cipher.h
+++ b/src/cipher.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017 Simon Désaulniers
+ * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
+ *
+ * This file is part of dpaste.
+ *
+ * dpaste is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dpaste is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <memory>
+#include <exception>
+#include <variant>
+
+namespace dpaste {
+namespace crypto {
+
+struct GPGParameters;
+using Parameters = std::variant<GPGParameters>;
+
+class Cipher {
+public:
+    enum class Scheme : int { NONE=0, GPG };
+
+    virtual ~Cipher () {}
+
+    static void init();
+
+    /**
+     * Process the plain text according to the cipher used.
+     *
+     * @param plain_text  The plain text.
+     * @param params      The parameters needed to process the plain text by the cipher.
+     *
+     * @return the resulting cipher_text
+     */
+    virtual std::vector<uint8_t>
+        processPlainText(std::vector<uint8_t> plain_text, std::shared_ptr<Parameters>&& params) = 0;
+
+    /**
+     * Process the cipher text according to the cipher used.
+     *
+     * @param plain_text  The cipher text.
+     * @param params      The parameters needed to process the cipher text by the cipher.
+     *
+     * @return the resulting plain text.
+     */
+    virtual std::vector<uint8_t>
+        processCipherText(std::vector<uint8_t> cipher_text, std::shared_ptr<Parameters>&& params) = 0;
+
+    /**
+     * Get a cipher by specifying the scheme to use (either GPG).
+     *
+     * @param scheme       The scheme to use (GPG).
+     * @param init_params  The initialization parameters if needed.
+     *
+     * @return A cipher
+     */
+    static std::shared_ptr<Cipher> get(Scheme scheme, std::shared_ptr<Parameters>&& init_params={});
+
+    /**
+     * Returns a cipher according to the cipher text put in parameters.
+     *
+     * @param cipher_text  The cipher text to guess the cipher from.
+     *
+     * @return A cipher
+     */
+    static std::shared_ptr<Cipher> get(const std::vector<uint8_t>& cipher_text);
+};
+
+struct GPGParameters {
+    const static Cipher::Scheme scheme = Cipher::Scheme::GPG;
+
+    std::string key_id;
+    std::vector<std::string> recipients;
+    bool self_recipient;
+    bool sign;
+
+    GPGParameters() {}
+    GPGParameters(std::string key_id) : key_id(key_id) {}
+    GPGParameters(std::vector<std::string> recipients, bool self_recipient, bool sign)
+        : recipients(recipients), self_recipient(self_recipient), sign(sign) {}
+};
+
+} /* crypto */
+} /* dpaste */
+
+/* vim:set et sw=4 ts=4 tw=120: */
+

--- a/src/cipher.h
+++ b/src/cipher.h
@@ -31,11 +31,12 @@ namespace dpaste {
 namespace crypto {
 
 struct GPGParameters;
-using Parameters = std::variant<GPGParameters>;
+struct AESParameters;
+using Parameters = std::variant<GPGParameters, AESParameters>;
 
 class Cipher {
 public:
-    enum class Scheme : int { NONE=0, GPG };
+    enum class Scheme : int { NONE=0, GPG, AES };
 
     virtual ~Cipher () {}
 
@@ -64,9 +65,9 @@ public:
         processCipherText(std::vector<uint8_t> cipher_text, std::shared_ptr<Parameters>&& params) = 0;
 
     /**
-     * Get a cipher by specifying the scheme to use (either GPG).
+     * Get a cipher by specifying the scheme to use (either GPG or AES).
      *
-     * @param scheme       The scheme to use (GPG).
+     * @param scheme       The scheme to use (GPG, AES).
      * @param init_params  The initialization parameters if needed.
      *
      * @return A cipher
@@ -80,7 +81,7 @@ public:
      *
      * @return A cipher
      */
-    static std::shared_ptr<Cipher> get(const std::vector<uint8_t>& cipher_text);
+    static std::shared_ptr<Cipher> get(const std::vector<uint8_t>& cipher_text, const std::string& pin);
 };
 
 struct GPGParameters {
@@ -95,6 +96,14 @@ struct GPGParameters {
     GPGParameters(std::string key_id) : key_id(key_id) {}
     GPGParameters(std::vector<std::string> recipients, bool self_recipient, bool sign)
         : recipients(recipients), self_recipient(self_recipient), sign(sign) {}
+};
+
+struct AESParameters {
+    const static Cipher::Scheme scheme = Cipher::Scheme::AES;
+    std::string password;
+
+    AESParameters() {}
+    AESParameters(std::string password) : password(password) {}
 };
 
 } /* crypto */

--- a/src/gpgcrypto.cpp
+++ b/src/gpgcrypto.cpp
@@ -76,7 +76,7 @@ std::vector<uint8_t> GPG::processPlainText(std::vector<uint8_t> plain_text, std:
 
     auto to_sign = gparams.sign and not signerKey_.empty();
     if (not gparams.recipients.empty()) {
-        DPASTE_MSG("Encrypting %sdata...", to_sign ? "and signing " : "");
+        DPASTE_MSG("Encrypting (gpg)%s...", to_sign ? " and signing " : "");
         auto res = encrypt(gparams.recipients, plain_text, to_sign);
         return std::get<0>(res);
     }
@@ -89,8 +89,7 @@ GPG::processCipherText(std::vector<uint8_t> cipher_text, std::shared_ptr<Paramet
 {
     auto gparams = params ? std::get<GPGParameters>(*params) : GPGParameters {};
 
-    DPASTE_MSG("Data is GPG encrypted.");
-    DPASTE_MSG("Decrypting...");
+    DPASTE_MSG("Decrypting (gpg)...");
     auto res = decryptAndVerify(cipher_text);
     DPASTE_MSG("Success!");
 

--- a/src/gpgcrypto.h
+++ b/src/gpgcrypto.h
@@ -32,12 +32,23 @@
 #include <gpgme++/signingresult.h>
 #include <gpgme++/verificationresult.h>
 
-namespace dpaste {
+#include "cipher.h"
 
-class GPGCrypto {
+namespace dpaste {
+namespace crypto {
+
+class GPG : public Cipher {
 public:
-    GPGCrypto(std::string signer);
-    virtual ~GPGCrypto () {}
+    GPG(std::string signer="");
+    virtual ~GPG () {}
+
+    static void init();
+
+    std::vector<uint8_t>
+        processPlainText(std::vector<uint8_t> plain_text, std::shared_ptr<Parameters>&& params) override;
+
+    std::vector<uint8_t>
+        processCipherText(std::vector<uint8_t> cipher_text, std::shared_ptr<Parameters>&& params) override;
 
     std::tuple<std::vector<uint8_t>,
         GpgME::EncryptionResult,
@@ -55,14 +66,19 @@ public:
 
     GpgME::VerificationResult verify(const std::vector<uint8_t>& signature, const std::vector<uint8_t>& plain_text) const;
 
-    bool isGPGencrypted(const std::vector<uint8_t>& d) const;
+    void comment_on_signature(const GpgME::Signature& sig);
+
+    static bool isGPGencrypted(const std::vector<uint8_t>& d);
 
 private:
     GpgME::Key getKey(const std::string& key_id) const;
 
     std::unique_ptr<GpgME::Context> ctx;
+    std::string signerKey_;
 };
 
+
+} /* crypto */
 } /* dpaste */
 
 /* vim:set et sw=4 ts=4 tw=120: */

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -77,7 +77,9 @@ void Node::get(const std::string& code, PastedCallback&& pcb) {
 }
 
 std::vector<dht::Blob> Node::get(const std::string& code) {
-    auto values = node_.get(dht::InfoHash::get(code), dht::Value::AllFilter(), dht::Where{}.userType(DPASTE_USER_TYPE)).get();
+    auto values = node_.get(dht::InfoHash::get(code),
+            dht::Value::AllFilter(),
+            dht::Where{}.userType(DPASTE_USER_TYPE)).get();
     std::vector<dht::Blob> blobs (values.size());
     std::transform(values.begin(), values.end(), blobs.begin(), [] (const decltype(values)::value_type& value) {
         return value->data;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,8 @@ dptest_SOURCES = \
 				 tests.cpp \
 				 bin.cpp \
 				 node.cpp \
-				 conf.cpp
+				 conf.cpp \
+				 aes.cpp
 
 # Variables defined in toplevel Makefile. Thus, `make check` cannot be called
 # from this directory.

--- a/tests/aes.cpp
+++ b/tests/aes.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2018 Simon Désaulniers
+ * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
+ *
+ * This file is part of dpaste.
+ *
+ * dpaste is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dpaste is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+
+#include <catch.hpp>
+
+#include "cipher.h"
+#include "aescrypto.h"
+
+namespace dpaste {
+namespace tests {
+
+TEST_CASE("AES process plain/cipher text", "[AES][processPlainText][processCipherText]") {
+    crypto::AES aes {};
+    std::vector<uint8_t> data {0,1,2,3,4};
+    auto pwd = "this_is_a_really_good_pwd";
+    auto p = std::make_shared<crypto::Parameters>();
+    auto pp = p;
+    p->emplace<crypto::AESParameters>(pwd);
+
+    auto ct = aes.processPlainText(data, std::move(p));
+    REQUIRE ( not ct.empty() );
+
+    auto pt = aes.processCipherText(ct, std::move(pp));
+    REQUIRE ( pt == data );
+}
+
+} /* tests */
+} /* dpaste */
+
+/* vim: set ts=4 sw=4 tw=120 et :*/
+

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
     Bin bin {};
     SECTION ( "pasting data {0,1,2,3,4}" ) {
         using pbt = PirateBinTester;
-        auto code = bin.paste(std::vector<uint8_t> {data});
+        auto code = bin.paste(std::vector<uint8_t> {data}, {});
         REQUIRE ( code.size() == pbt::LOCATION_CODE_LEN+sizeof(pbt::DPASTE_URI_PREFIX)-1 );
 
         SECTION ( "getting pasted blob back from the DHT" ) {


### PR DESCRIPTION
A new class `Cipher` has been introduced in order to capture the common interface on all different ciphers. The two following functions describe the interface of a cipher:

```cpp
virtual std::vector<uint8_t> processPlainText(std::vector<uint8_t> plain_text, std::shared_ptr<Parameters>&& params);

virtual std::vector<uint8_t> processCipherText(std::vector<uint8_t> cipher_text, std::shared_ptr<Parameters>&& params);
```

The above is combined with two structures that are used to pass parameters depending on the cipher used.

```cpp
struct GPGParameters;
struct AESParameters;
using Parameters = std::variant<GPGParameters, AESParameters>;
```

In each case, a cipher will process the (cipher/plain)text using the same functions which are implemented differently for each particular ciphers.

**N.B**: Since the new instruction `std::variant` is used, the program now depends on `c++17`.