### PR TITLE
Cmake: fix regression with config.h support and cipher/aescrypto components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ list(APPEND dpaste_HEADERS
     src/bin.h
     src/gpgcrypto.h
     src/log.h
+	src/cipher.h
+	src/aescrypto.h
 )
 list(APPEND dpaste_SOURCES
     src/main.cpp
@@ -41,6 +43,8 @@ list(APPEND dpaste_SOURCES
     src/bin.cpp
     src/gpgcrypto.cpp
     src/log.cpp
+	src/cipher.cpp
+	src/aescrypto.cpp
 )
 
 #################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(dpaste_VERSION 0.3.3)
 add_definitions(-DVERSION="${dpaste_VERSION}")
 add_definitions(-DPACKAGE_NAME="dpaste")
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 ###################

--- a/src/bin.h
+++ b/src/bin.h
@@ -28,7 +28,9 @@
 #include <map>
 #include <utility>
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 #include "node.h"
 #include "http_client.h"
 #include "cipher.h"

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -23,7 +23,9 @@
 #include <stdio.h>
 #include <stdarg.h>
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
 #include "log.h"
 
 static constexpr const char* DPASTE_MSG_PREFIX = "DPASTE: ";

--- a/src/node.h
+++ b/src/node.h
@@ -30,7 +30,9 @@
 #include <opendht/rng.h>
 #include <opendht/callbacks.h>
 
+#ifdef HAVE_CONFG_H
 #include "config.h"
+#endif
 
 namespace dpaste {
 #ifdef DPASTE_TEST


### PR DESCRIPTION
Cmake was not able to compile correctly since dbc6a1f4f99836f7efd1a9a211f571a07efcdec5, according to my bisecting. This should fix #13.