### PR TITLE
cmake: configure nlohmann_json install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(glibmm REQUIRED)
 find_package(B64 REQUIRED)
 find_package(Gpgme)
 find_package(Threads REQUIRED)
+find_package(nlohmann_json 2.1.1 REQUIRED)
 
 #####################################
 #  dpaste headers and source files  #


### PR DESCRIPTION
This is a fix for #11.

~~Still WIP and not yet tested. Can be tested appropriately on the [`nlohmann_json-test`](https://github.com/sim590/dpaste/tree/cmake-nlohmann_json-test) branch.~~