### PR TITLE
WIP: Splitting a file in several packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Makefile.in
 *.l[ao]
 *~
 *.pc
+*.a
 
 # CMake dir
 build

--- a/src/aescrypto.cpp
+++ b/src/aescrypto.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/aescrypto.h
+++ b/src/aescrypto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/aescrypto.h
+++ b/src/aescrypto.h
@@ -33,15 +33,10 @@ class AES : public Cipher {
 public:
     /**
      * Length of the PIN if it contains the password for encrypted pasted data.
-     * It consists of 16 hexadecimal characters: 16*4 = 64 bits. Last 32 bits
-     * encode the password. Otherwise, PIN should be 32 bits.
+     * It consists of 18 hexadecimal characters: 18*4 = 72 bits. Last 32 bits
+     * encode the password. Otherwise, PIN should be 40 bits.
      */
-    static const constexpr size_t PIN_WITH_PASS_LEN {16};
-    /**
-     * Number of bytes offsetting the password in the binary representation of
-     * the hexadecimal password.
-     */
-    static const constexpr size_t CODE_PASS_OFFSET {4};
+    static const constexpr size_t PIN_WITH_PASS_LEN {18};
 
     AES() {}
     virtual ~AES () {}

--- a/src/aescrypto.h
+++ b/src/aescrypto.h
@@ -31,13 +31,6 @@ namespace crypto {
 
 class AES : public Cipher {
 public:
-    /**
-     * Length of the PIN if it contains the password for encrypted pasted data.
-     * It consists of 18 hexadecimal characters: 18*4 = 72 bits. Last 32 bits
-     * encode the password. Otherwise, PIN should be 40 bits.
-     */
-    static const constexpr size_t PIN_WITH_PASS_LEN {18};
-
     AES() {}
     virtual ~AES () {}
 

--- a/src/bin.cpp
+++ b/src/bin.cpp
@@ -57,7 +57,7 @@ Bin::Bin() {
 std::string Bin::code_from_dpaste_uri(const std::string& uri) {
     static const std::string DUP {DPASTE_URI_PREFIX};
     const auto p = uri.find(DUP);
-    return uri.substr(p != std::string::npos ? p+DUP.length() : 0);
+    return uri.substr(p != std::string::npos ? p+DUP.length() : 0, crypto::AES::PIN_WITH_PASS_LEN);
 }
 
 std::tuple<std::string, uint32_t, std::string>

--- a/src/bin.cpp
+++ b/src/bin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/bin.cpp
+++ b/src/bin.cpp
@@ -23,6 +23,8 @@
 #include <array>
 #include <iomanip>
 #include <memory>
+#include <algorithm>
+#include <unistd.h>
 
 #include <msgpack.hpp>
 
@@ -38,7 +40,7 @@ const constexpr uint8_t Bin::PROTO_VERSION;
 
 Bin::Bin() {
     /* load dpaste config */
-    auto config_file = conf::ConfigurationFile();
+    conf::ConfigurationFile config_file {};
     config_file.load();
     conf_ = config_file.getConfiguration();
 
@@ -58,29 +60,31 @@ std::string Bin::code_from_dpaste_uri(const std::string& uri) {
     return uri.substr(p != std::string::npos ? p+DUP.length() : 0);
 }
 
-std::pair<bool, std::string> Bin::get(std::string&& code, bool no_decrypt) {
-    code = code_from_dpaste_uri(code);
-    const auto offset = crypto::AES::CODE_PASS_OFFSET*2;
-    const auto lcode = code.substr(0, offset);
-    const auto pwd = code.substr(offset);
+std::tuple<std::string, uint32_t, std::string>
+Bin::parse_code_info(const std::string& code) {
+    std::stringstream ns(code.substr(Bin::DPASTE_PIN_LEN, Bin::DPASTE_NPACKETS_LEN));
+    uint32_t npackets;
+    ns >> std::hex >> npackets;
+    return {
+        code.substr(0, Bin::DPASTE_PIN_LEN),
+        npackets,
+        code.substr(Bin::DPASTE_PIN_LEN+Bin::DPASTE_NPACKETS_LEN)
+    };
+}
 
-    /* first try http server */
-    auto data_str = http_client_->get(lcode);
-    std::vector<uint8_t> data {data_str.begin(), data_str.end()};
-
-    /* if fail, then perform request from local node */
-    if (data.empty()) {
-        /* get a pasted blob */
-        auto values = node.get(lcode);
-        if (not values.empty())
-            data = values.front();
-    }
-
-    if (not data.empty()) {
-        Packet p;
+std::vector<uint8_t>
+Bin::parse_data(const std::string& code,
+                std::vector<std::vector<uint8_t>>&& values,
+                std::string pwd,
+                bool no_decrypt) const
+{
+    for (const auto& v : values) {
         try {
-            p.deserialize(data);
+            Packet p;
+            p.deserialize(v);
+            std::vector<uint8_t> data;
             auto cipher = crypto::Cipher::get(p.data, code);
+
             if (cipher and not no_decrypt) {
                 std::shared_ptr<crypto::Parameters> params;
                 if (auto aes = std::dynamic_pointer_cast<crypto::AES>(cipher)) {
@@ -90,6 +94,7 @@ std::pair<bool, std::string> Bin::get(std::string&& code, bool no_decrypt) {
                 data = cipher->processCipherText(p.data, std::move(params));
             } else
                 data = std::move(p.data);
+
             if (not (cipher or p.signature.empty())) {
                 auto gc = std::dynamic_pointer_cast<crypto::GPG>(crypto::Cipher::get(crypto::Cipher::Scheme::GPG, {}));
                 DPASTE_MSG("Data is GPG signed. Verifying...");
@@ -97,45 +102,89 @@ std::pair<bool, std::string> Bin::get(std::string&& code, bool no_decrypt) {
                 if (res.numSignatures() > 0)
                     gc->comment_on_signature(res.signature(0));
             }
+
+            return data;
         } catch (const GpgME::Exception& e) {
             DPASTE_MSG("%s", e.what());
-            return {false, ""};
+            return {};
         } catch (const dht::crypto::DecryptError& e) {
             DPASTE_MSG("%s", e.what());
-            return {false, ""};
+            return {};
         } catch (msgpack::type_error& e) { } /* backward compatibility with <=0.3.3 */
-
     }
-    return {true, {data.begin(), data.end()}};
+
+    return {};
 }
 
-std::vector<uint8_t> Bin::data_from_stream(std::stringstream&& input_stream) {
+std::pair<bool, std::string> Bin::get(std::string&& code, bool no_decrypt) {
+    code = code_from_dpaste_uri(code);
+    const auto parsed_code = parse_code_info(code);
+    const auto& lcode      = std::get<0>(parsed_code);
+    const auto& npackets   = std::get<1>(parsed_code);
+    const auto& pwd        = std::get<2>(parsed_code);
+
+    std::vector<Packet> packets(npackets);
+
+    auto available = http_client_->isAvailable();
+    auto get_method = [this,&available](const auto& c) {
+        /* if available, try http server */
+        if (available) {
+            auto datas = http_client_->get(c);
+            std::vector<std::vector<uint8_t>> data;
+            std::transform(datas.begin(), datas.end(), std::back_inserter(data), [](const auto& s) {
+                std::vector<uint8_t> blob;
+                std::move(s.begin(), s.end(), std::back_inserter(blob));
+                return blob;
+            });
+            return data;
+        /* if fail, then perform request from local node */
+        } else return node.get(c);
+    };
+
+    std::vector<uint8_t> whole_data;
+    uint32_t licode;
+    {
+        std::stringstream css(lcode);
+        css >> std::hex >> licode;
+    }
+    for (uint8_t s = 0; s < npackets; ++s) {
+        std::string target = code_from_pin(licode + s);
+        auto values        = get_method(target);
+        auto data          = parse_data(code, std::move(values), pwd, no_decrypt);
+        if (data.empty())
+            return {false, {}};
+        std::move(data.begin(), data.end(), std::back_inserter(whole_data));
+    }
+
+    std::string ret;
+    std::move(whole_data.begin(), whole_data.end(), std::back_inserter(ret));
+    return {true, std::move(ret)};
+}
+
+std::vector<uint8_t> Bin::data_from_stream(std::stringstream& input_stream, const size_t& count) {
     std::vector<uint8_t> buffer;
-    buffer.resize(dht::MAX_VALUE_SIZE);
-    input_stream.read(reinterpret_cast<char*>(buffer.data()), dht::MAX_VALUE_SIZE);
+    buffer.resize(count);
+    input_stream.read(reinterpret_cast<char*>(buffer.data()), count);
     buffer.resize(input_stream.gcount());
     return buffer;
 }
 
-std::string Bin::random_pin() {
-    static std::uniform_int_distribution<uint32_t> dist;
-    static std::mt19937_64 rand_;
-    static dht::crypto::random_device rdev;
-    static std::seed_seq seed {rdev(), rdev()};
-    static bool initialized = false;
-    if (not initialized)
-        rand_.seed(seed);
-
-    auto pin = dist(rand_);
-    std::stringstream ss;
-    ss << std::setfill('0') << std::setw(Bin::DPASTE_PIN_LEN) << std::hex << pin;
-    auto pin_s = ss.str();
+std::string Bin::code_from_pin(uint32_t pin) {
+    auto pin_s = hexStrFromInt(pin, Bin::DPASTE_PIN_LEN);
     std::transform(pin_s.begin(), pin_s.end(), pin_s.begin(), ::toupper);
     return pin_s;
 }
 
-std::pair<Bin::Packet, std::string> Bin::prepare_data(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params) {
-    Packet p;
+std::string Bin::hexStrFromInt(uint32_t i, size_t len) {
+    std::stringstream ss;
+    ss << std::setfill('0') << std::setw(len) << std::hex << i;
+    return ss.str();
+}
+
+std::pair<std::vector<Bin::Packet>, std::string>
+Bin::prepare_data(std::stringstream&& input_stream,
+                  std::unique_ptr<crypto::Parameters>&& params)
+{
     std::string pwd = "";
     std::shared_ptr<crypto::Parameters> sparams(std::move(params));
     std::shared_ptr<crypto::Parameters> init_params;
@@ -144,48 +193,75 @@ std::pair<Bin::Packet, std::string> Bin::prepare_data(std::vector<uint8_t>&& dat
     bool to_sign {false};
     if (auto gp = std::get_if<crypto::GPGParameters>(sparams.get())) {
         auto& keyid = conf_.at("pgp_key_id");
-        to_sign = gp->sign and not keyid.empty();
-        scheme = gp->scheme;
+        to_sign     = gp->sign and not keyid.empty();
+        scheme      = gp->scheme;
         init_params = std::make_shared<crypto::Parameters>();
         init_params->emplace<crypto::GPGParameters>(keyid);
     } else if (auto aesp = std::get_if<crypto::AESParameters>(sparams.get())) {
-        scheme = aesp->scheme;
-        pwd = random_pin();
+        scheme         = aesp->scheme;
+        pwd            = random_pin();
         aesp->password = pwd;
     }
 
     auto cipher = crypto::Cipher::get(scheme, std::move(init_params));
 
-    if (cipher) {
-        auto cipher_text = cipher->processPlainText(data, std::move(sparams));
-        if (cipher_text.empty()) {
-            p.data.insert(p.data.end(), data.begin(), data.end());
-            if (to_sign) {
-                DPASTE_MSG("Signing data...");
-                auto res = std::dynamic_pointer_cast<crypto::GPG>(cipher)->sign(p.data);
-                p.signature = res.first;
-            }
+    uint32_t rsiz = 0;
+    const size_t SIZE_PER_PACKET = dht::MAX_VALUE_SIZE - Packet::EXTRA_SERIALIZATION_BYTES;
+    std::vector<Packet> packets;
+    packets.reserve(std::ceil(((double)Bin::DPASTE_MAX_SIZE) / SIZE_PER_PACKET));
+    std::vector<uint8_t> data;
+    while (rsiz < Bin::DPASTE_MAX_SIZE
+           and (data = data_from_stream(input_stream, SIZE_PER_PACKET)).size() > 0)
+    {
+        rsiz += data.size();
+
+        Packet p;
+        if (cipher) {
+            auto cipher_text = cipher->processPlainText(data, std::move(sparams));
+            if (cipher_text.empty()) {
+                p.data.insert(p.data.end(), data.begin(), data.end());
+                if (to_sign) {
+                    DPASTE_MSG("Signing data...");
+                    auto res = std::dynamic_pointer_cast<crypto::GPG>(cipher)->sign(p.data);
+                    p.signature = std::move(res.first);
+                }
+            } else
+                p.data = std::move(cipher_text);
         } else
-            p.data = cipher_text;
-    } else
-        p.data.insert(p.data.end(), data.begin(), data.end());
-    return {p, pwd};
+            p.data = std::move(data);
+
+        packets.push_back(std::move(p));
+    }
+
+    packets.shrink_to_fit();
+    return {packets, std::move(pwd)};
 }
 
-std::string Bin::paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params) {
-    auto code = random_pin();
+std::string
+Bin::paste(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>&& params) {
+    auto pin          = random_.integer();
+    auto available    = http_client_->isAvailable();
+    auto paste_method = [this,&available](const auto& c, auto&& d) {
+        if (available) return http_client_->put(c, {d.begin(), d.end()});
+        else           return node.paste(c, std::forward<std::vector<uint8_t>>(d));
+    };
 
-    auto pp = prepare_data(std::forward<std::vector<uint8_t>>(data), std::forward<std::unique_ptr<crypto::Parameters>>(params));
-    auto& p = pp.first;
-    auto& pwd = pp.second;
+    auto pp = prepare_data(std::forward<std::stringstream>(input_stream),
+                                std::forward<std::unique_ptr<crypto::Parameters>>(params));
+    auto& packets = pp.first;
+    auto& pwd     = pp.second;
 
     DPASTE_MSG("Pasting data...");
-    auto bin_packet = p.serialize();
-    auto success = http_client_->put(code, {bin_packet.begin(), bin_packet.end()});
-    if (not success)
-        success = node.paste(code, std::move(bin_packet));
+    size_t shift = 0;
+    for (const auto& p : packets) {
+        auto code       = code_from_pin(pin + shift++);
+        auto bin_packet = p.serialize();
+        bool success    = paste_method(code, std::move(bin_packet));
+        if (not success)
+            return {};
+    }
 
-    return success ? DPASTE_URI_PREFIX+code+pwd  : "";
+    return DPASTE_URI_PREFIX+code_from_pin(pin)+hexStrFromInt(shift, Bin::DPASTE_NPACKETS_LEN)+pwd;
 }
 
 msgpack::object*

--- a/src/bin.cpp
+++ b/src/bin.cpp
@@ -63,12 +63,13 @@ std::string Bin::code_from_dpaste_uri(const std::string& uri) {
 std::tuple<std::string, uint32_t, std::string>
 Bin::parse_code_info(const std::string& code) {
     std::stringstream ns(code.substr(Bin::DPASTE_PIN_LEN, Bin::DPASTE_NPACKETS_LEN));
+    const auto PWD_LEN = crypto::AES::PIN_WITH_PASS_LEN - Bin::DPASTE_PIN_LEN - Bin::DPASTE_NPACKETS_LEN;
     uint32_t npackets;
     ns >> std::hex >> npackets;
     return {
         code.substr(0, Bin::DPASTE_PIN_LEN),
         npackets,
-        code.substr(Bin::DPASTE_PIN_LEN+Bin::DPASTE_NPACKETS_LEN)
+        code.substr(Bin::DPASTE_PIN_LEN+Bin::DPASTE_NPACKETS_LEN, PWD_LEN)
     };
 }
 

--- a/src/bin.cpp
+++ b/src/bin.cpp
@@ -29,6 +29,8 @@
 #include <msgpack.hpp>
 
 #include "bin.h"
+
+#include "code.h"
 #include "conf.h"
 #include "log.h"
 #include "gpgcrypto.h"
@@ -57,19 +59,18 @@ Bin::Bin() {
 std::string Bin::code_from_dpaste_uri(const std::string& uri) {
     static const std::string DUP {DPASTE_URI_PREFIX};
     const auto p = uri.find(DUP);
-    return uri.substr(p != std::string::npos ? p+DUP.length() : 0, crypto::AES::PIN_WITH_PASS_LEN);
+    return uri.substr(p != std::string::npos ? p+DUP.length() : 0, code::PIN_WITH_PASS_LEN);
 }
 
 std::tuple<std::string, uint32_t, std::string>
 Bin::parse_code_info(const std::string& code) {
-    std::stringstream ns(code.substr(Bin::DPASTE_PIN_LEN, Bin::DPASTE_NPACKETS_LEN));
-    const auto PWD_LEN = crypto::AES::PIN_WITH_PASS_LEN - Bin::DPASTE_PIN_LEN - Bin::DPASTE_NPACKETS_LEN;
+    std::stringstream ns(code.substr(code::DPASTE_PIN_LEN, code::DPASTE_NPACKETS_LEN));
     uint32_t npackets;
     ns >> std::hex >> npackets;
     return {
-        code.substr(0, Bin::DPASTE_PIN_LEN),
+        code.substr(0, code::DPASTE_PIN_LEN),
         npackets,
-        code.substr(Bin::DPASTE_PIN_LEN+Bin::DPASTE_NPACKETS_LEN, PWD_LEN)
+        code.substr(code::DPASTE_PIN_LEN+code::DPASTE_NPACKETS_LEN, code::PASSWORD_LEN)
     };
 }
 
@@ -171,7 +172,7 @@ std::vector<uint8_t> Bin::data_from_stream(std::stringstream& input_stream, cons
 }
 
 std::string Bin::code_from_pin(uint32_t pin) {
-    auto pin_s = hexStrFromInt(pin, Bin::DPASTE_PIN_LEN);
+    auto pin_s = hexStrFromInt(pin, code::DPASTE_PIN_LEN);
     std::transform(pin_s.begin(), pin_s.end(), pin_s.begin(), ::toupper);
     return pin_s;
 }
@@ -262,7 +263,7 @@ Bin::paste(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>
             return {};
     }
 
-    return DPASTE_URI_PREFIX+code_from_pin(pin)+hexStrFromInt(shift, Bin::DPASTE_NPACKETS_LEN)+pwd;
+    return DPASTE_URI_PREFIX+code_from_pin(pin)+hexStrFromInt(shift, code::DPASTE_NPACKETS_LEN)+pwd;
 }
 
 msgpack::object*

--- a/src/bin.h
+++ b/src/bin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/bin.h
+++ b/src/bin.h
@@ -47,14 +47,6 @@ class Bin {
 public:
 
     /**
-     * Number of bytes in a dpaste code accounting for the number of packets the
-     * file was split into
-     */
-    static const constexpr unsigned int DPASTE_NPACKETS_LEN {2};
-    /**
-     * Number of bytes in a dpaste code accounting for the location PIN. */
-    static const constexpr unsigned int DPASTE_PIN_LEN {8};
-    /**
      * Maximal size to be read from the input stream and pasted on the DHT
      * (possibly split in several packets).
      */

--- a/src/bin.h
+++ b/src/bin.h
@@ -46,7 +46,19 @@ class Bin {
 #endif
 public:
 
+    /**
+     * Number of bytes in a dpaste code accounting for the number of packets the
+     * file was split into
+     */
+    static const constexpr unsigned int DPASTE_NPACKETS_LEN {2};
+    /**
+     * Number of bytes in a dpaste code accounting for the location PIN. */
     static const constexpr unsigned int DPASTE_PIN_LEN {8};
+    /**
+     * Maximal size to be read from the input stream and pasted on the DHT
+     * (possibly split in several packets).
+     */
+    static const constexpr size_t DPASTE_MAX_SIZE {2 * 1024 * 1024};
 
     Bin();
     virtual ~Bin () {}
@@ -69,11 +81,13 @@ public:
      *
      * @return the code (key) to the pasted data. If empty, then process failed.
      */
-    std::string paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params);
-    std::string paste(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>&& params) {
-        return paste(data_from_stream(std::move(input_stream)),
-                std::forward<std::unique_ptr<crypto::Parameters>>(params));
+    std::string paste(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params) {
+        std::string is;
+        std::move(data.begin(), data.end(), std::back_inserter(is));
+        std::stringstream ss(std::move(is));
+        return paste(std::move(ss), std::forward<std::unique_ptr<crypto::Parameters>>(params));
     }
+    std::string paste(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>&& params);
 
 private:
     /* constants */
@@ -81,6 +95,13 @@ private:
     static const constexpr uint8_t PROTO_VERSION = 0;
 
     struct Packet {
+        /**
+         * Bytes needed for the two layers of serialization. This accounts for
+         * dpaste's usage of msgpack as well as OpenDHT's and GPG
+         * encryption/signature.
+         */
+        static const constexpr size_t EXTRA_SERIALIZATION_BYTES {12 * 1024};
+
         std::vector<uint8_t> data {};
         std::vector<uint8_t> signature {};
 
@@ -88,25 +109,67 @@ private:
         void deserialize(const std::vector<uint8_t>& pbuffer);
     };
 
+    /*!
+     * @class   Random
+     * @brief   Random number generator state encapsulator.
+     * @details
+     * The structure contains the the state of the random number generator used
+     * by the Bin class to perform its random code generation. The structure
+     * is embeded inside the Bin class as a private member.
+     */
+    struct Random {
+        Random() {
+            dht::crypto::random_device rdev;
+            std::seed_seq seed {rdev(), rdev()};
+            gen.seed(seed);
+        }
+
+        inline uint32_t integer() { return dist(gen); }
+
+        std::uniform_int_distribution<uint32_t> dist;
+        std::mt19937_64 gen;
+    };
+
     /**
      * Create a Packet from input data and crypto parameters.
      *
-     * @param data    input data in bytes.
-     * @param params  cryptographic parameters (either GPGParameters or
-     *                AESParameters).
+     * @param input_stream  input data stream of bytes.
+     * @param params        cryptographic parameters (either GPGParameters or
+     *                      AESParameters).
      *
      * @return an ordered pair of a Packet and associated password.
      */
-    std::pair<Bin::Packet, std::string> prepare_data(std::vector<uint8_t>&& data, std::unique_ptr<crypto::Parameters>&& params);
+    std::pair<std::vector<Bin::Packet>, std::string>
+    prepare_data(std::stringstream&& input_stream, std::unique_ptr<crypto::Parameters>&& params);
+
+    /**
+     * Parses the DHT values recovered from the DHT get operation and returns
+     * the first value found the the given code identifier.
+     *
+     * @param code        String of bytes consisting in the location code
+     *                    information.
+     * @param values      The values to parse.
+     * @param pwd         The password used to decrypt the AES encrypted data
+     *                    (if it was present in the input code).
+     * @param no_decrypt  A bool indicating if the data should be decrypted
+     *                    before being returned.
+     *
+     * @return The value (or part of the value) recovered from the DHT.
+     */
+    std::vector<uint8_t> parse_data(const std::string& code,
+                                     std::vector<std::vector<uint8_t>>&& values,
+                                     std::string pwd,
+                                     bool no_decrypt) const;
 
     /**
      * Get data from input stream.
      *
      * @param input_stream  The stream to read to get the data.
+     * @param count         Number of bytes to be read from the stream.
      *
      * @return the data
      */
-    static std::vector<uint8_t> data_from_stream(std::stringstream&& input_stream);
+    static std::vector<uint8_t> data_from_stream(std::stringstream& input_stream, const size_t& count);
 
     /**
      * Parse dpaste uri for code.
@@ -117,13 +180,52 @@ private:
      */
     static std::string code_from_dpaste_uri(const std::string& uri);
 
-    static std::string random_pin();
+    /**
+     * Parses the input code into three separate parts consisting respectivly in
+     * the location code information, the number of packets the file is split
+     * into and the password used to decrypt AES encrypted data.
+     *
+     * @param code  The input code.
+     *
+     * @return The tuple described above.
+     */
+    static std::tuple<std::string, uint32_t, std::string> parse_code_info(const std::string& code);
 
+    /**
+     * Converts a number into its hexadecimal `len` bytes long string value
+     * with zeroes padding in prefix when necessary.
+     *
+     * @param i    The integer.
+     * @param len  The length of the resulting string.
+     *
+     * @return the resulting hexadecimal string representation of the integer.
+     */
+    static std::string hexStrFromInt(uint32_t i, size_t len);
+
+    /**
+     * Converts a PIN number into a string code, i.e. an hexadecimal string
+     * representation of the PIN in upper case.
+     *
+     * @param i  The integer.
+     *
+     * @return the resulting hexadecimal string representation of the integer.
+     */
+    static std::string code_from_pin(uint32_t i);
+
+    /**
+     * Generates a random PIN using a 32-bit random number generator. The
+     * resulting string describes a 32-bit value.
+     */
+    inline std::string random_pin() { return code_from_pin(random_.integer()); }
+
+    /* A map containing the configuration read from the config file on disk. */
     std::map<std::string, std::string> conf_;
 
     /* transport */
     std::unique_ptr<HttpClient> http_client_ {};
     Node node {};
+
+    Random random_ {};
 };
 
 } /* dpaste */

--- a/src/cipher.cpp
+++ b/src/cipher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/cipher.cpp
+++ b/src/cipher.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "cipher.h"
+
+#include "code.h"
 #include "gpgcrypto.h"
 #include "aescrypto.h"
 
@@ -37,7 +39,7 @@ void Cipher::init() {
 std::shared_ptr<Cipher> Cipher::get(const std::vector<uint8_t>& cipher_text, const std::string& pin="") {
     if (GPG::isGPGencrypted(cipher_text))
         return std::make_shared<GPG>();
-    else if (pin.size() == AES::PIN_WITH_PASS_LEN)
+    else if (pin.size() == code::PIN_WITH_PASS_LEN)
         return std::make_shared<AES>();
     return {};
 }

--- a/src/cipher.h
+++ b/src/cipher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/code.h
+++ b/src/code.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020 Simon Désaulniers
+ * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
+ *
+ * This file is part of dpaste.
+ *
+ * dpaste is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * dpaste is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace dpaste {
+namespace code {
+
+/**
+ * Number of bytes in a dpaste code accounting for the number of packets the
+ * file was split into
+ */
+static const constexpr unsigned int DPASTE_NPACKETS_LEN {2};
+/**
+ * Number of bytes in a dpaste code accounting for the location PIN. */
+static const constexpr unsigned int DPASTE_PIN_LEN {8};
+
+/**
+ * Number of bytes used to encode the AES password.
+ */
+static const constexpr size_t PASSWORD_LEN {8};
+
+/**
+ * Length of the PIN if it contains the password for encrypted pasted data.
+ * It consists of 18 hexadecimal characters: 18*4 = 72 bits. Last 32 bits
+ * encode the password. Otherwise, PIN should be 40 bits.
+ */
+static const constexpr size_t PIN_WITH_PASS_LEN {DPASTE_PIN_LEN + DPASTE_NPACKETS_LEN + PASSWORD_LEN};
+
+}
+} /* dpaste */
+
+/* vim: set sts=4 ts=4 sw=4 tw=120 et :*/
+

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/conf.h
+++ b/src/conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/gpgcrypto.cpp
+++ b/src/gpgcrypto.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/gpgcrypto.h
+++ b/src/gpgcrypto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <vector>
 #include <string>
 
 namespace dpaste {
@@ -29,7 +30,28 @@ public:
     HttpClient (std::string host, long port) : host(host), port(port) {}
     virtual ~HttpClient () {}
 
-    std::string get(const std::string& code) const;
+    /**
+     * Tells if the server responds to requests.
+     */
+    bool isAvailable() const;
+
+    /**
+     * Send a GET request to the REST server.
+     *
+     * @param code  The location code.
+     *
+     * @return A vector of the values recovered from the DHT by the REST server.
+     */
+    std::vector<std::string> get(const std::string& code) const;
+
+    /**
+     * Send a PUT request to the REST server.
+     *
+     * @param code  The location code.
+     * @param data  The data to publish.
+     *
+     * @return True if the server accepted and completed the request, false otherwise.
+     */
     bool put(const std::string& code, const std::string& data) const;
 
 private:

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/log.h
+++ b/src/log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,7 @@ ParsedArgs parseArgs(int argc, char *argv[]) {
 }
 
 void print_help() {
-    std::cout << PACKAGE_NAME << " -- A simple pastebin for light values (max 64KB)"
+    std::cout << PACKAGE_NAME << " -- A simple pastebin (for values of size up to 2MB)"
                               << " using OpenDHT distributed hash table." << std::endl << std::endl;
 
     std::cout << "SYNOPSIS" << std::endl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,7 @@ ParsedArgs parseArgs(int argc, char *argv[]) {
 }
 
 void print_help() {
-    std::cout << PACKAGE_NAME << " -- A simple pastebin (for values of size up to 2MB)"
+    std::cout << PACKAGE_NAME << " -- A simple pastebin (for values of size up to 2MiB)"
                               << " using OpenDHT distributed hash table." << std::endl << std::endl;
 
     std::cout << "SYNOPSIS" << std::endl

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/src/node.h
+++ b/src/node.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Simon Désaulniers
+ * Copyright © 2017-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/tests/aes.cpp
+++ b/tests/aes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Simon Désaulniers
+ * Copyright © 2018-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -83,6 +83,22 @@ TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
     SECTION ( "pasting AES encrypted {0,1,2,3,4}" ) {
         test_paste_encrypted(bin, data);
     }
+    SECTION ( "pasting data (size over 64KB)" ) {
+        std::array<size_t, 4> sizes = {32 * 1024, 64 * 1024, 512 * 1024};
+        for (const auto& s : sizes) {
+            std::stringstream ss;
+            ss << s;
+            SECTION ( "trying for size of " + ss.str() + "B" ) {
+                std::vector<uint8_t> buffer(s);
+                SECTION ( "plain data" ) {
+                    test_paste(bin, buffer);
+                }
+                SECTION ( "AES encrypted data" ) {
+                    test_paste_encrypted(bin, buffer);
+                }
+            }
+        }
+    }
 }
 
 TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste_uri]") {

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -41,8 +41,8 @@ public:
         return Bin::code_from_dpaste_uri(uri);
     }
 
-    std::vector<uint8_t> data_from_stream(std::stringstream&& input_stream) const {
-        return Bin::data_from_stream(std::forward<std::stringstream>(input_stream));
+    std::vector<uint8_t> data_from_stream(std::stringstream& input_stream, size_t count) const {
+        return Bin::data_from_stream(input_stream, count);
     }
 };
 
@@ -117,7 +117,7 @@ TEST_CASE("Bin conversion of stringstream to vector", "[Bin][data_from_stream]")
     const std::string DATA = "SOME DATA";
     std::stringstream ss(DATA);
     std::vector<uint8_t> d {DATA.begin(), DATA.end()};
-    REQUIRE ( pt.data_from_stream(std::move(ss)) == d );
+    REQUIRE ( pt.data_from_stream(ss, DATA.size()) == d );
 }
 
 } /* tests */

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -20,11 +20,11 @@
 
 #include <algorithm>
 
-#include <catch.hpp>
-
 #include "code.h"
 #include "tests.h"
 #include "bin.h"
+
+#include "catch.h"
 
 namespace dpaste {
 namespace tests {
@@ -50,12 +50,12 @@ public:
 void test_paste(Bin& bin, const std::vector<uint8_t>& data) {
     using pbt = PirateBinTester;
     auto code = bin.paste(std::vector<uint8_t> {data}, {});
-    REQUIRE ( code.size() == pbt::dpaste_uri_prefix().size()+code::DPASTE_PIN_LEN+code::DPASTE_NPACKETS_LEN );
+    CATCH_REQUIRE ( code.size() == pbt::dpaste_uri_prefix().size()+code::DPASTE_PIN_LEN+code::DPASTE_NPACKETS_LEN );
 
-    SECTION ( "getting pasted blob back from the DHT" ) {
+    CATCH_SECTION ( "getting pasted blob back from the DHT" ) {
         auto rd = bin.get(std::move(code)).second;
         std::vector<uint8_t> rdv {rd.begin(), rd.end()};
-        REQUIRE ( data == rdv );
+        CATCH_REQUIRE ( data == rdv );
     }
 }
 
@@ -64,36 +64,36 @@ void test_paste_encrypted(Bin& bin, const std::vector<uint8_t>& data) {
     auto p = std::make_unique<dpaste::crypto::Parameters>();
     p->emplace<crypto::AESParameters>();
     auto code = bin.paste(std::vector<uint8_t> {data}, std::move(p));
-    REQUIRE ( code.size() == pbt::dpaste_uri_prefix().size()+code::DPASTE_PIN_LEN+code::DPASTE_NPACKETS_LEN+code::PASSWORD_LEN );
+    CATCH_REQUIRE ( code.size() == pbt::dpaste_uri_prefix().size()+code::DPASTE_PIN_LEN+code::DPASTE_NPACKETS_LEN+code::PASSWORD_LEN );
 
-    SECTION ( "getting pasted AES encrypted blob back from the DHT" ) {
+    CATCH_SECTION ( "getting pasted AES encrypted blob back from the DHT" ) {
         auto rd = bin.get(std::move(code)).second;
         std::vector<uint8_t> rdv {rd.begin(), rd.end()};
-        REQUIRE ( data == rdv );
+        CATCH_REQUIRE ( data == rdv );
     }
 }
 
-TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
+CATCH_TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
     std::vector<uint8_t> data = {0, 1, 2, 3, 4};
     Bin bin {};
     crypto::Cipher::init();
-    SECTION ( "pasting data {0,1,2,3,4}" ) {
+    CATCH_SECTION ( "pasting data {0,1,2,3,4}" ) {
         test_paste(bin, data);
     }
-    SECTION ( "pasting AES encrypted {0,1,2,3,4}" ) {
+    CATCH_SECTION ( "pasting AES encrypted {0,1,2,3,4}" ) {
         test_paste_encrypted(bin, data);
     }
-    SECTION ( "pasting data (size over 64KB)" ) {
+    CATCH_SECTION ( "pasting data (size over 64KB)" ) {
         std::array<size_t, 4> sizes = {32 * 1024, 64 * 1024, 512 * 1024};
         for (const auto& s : sizes) {
             std::stringstream ss;
             ss << s;
-            SECTION ( "trying for size of " + ss.str() + "B" ) {
+            CATCH_SECTION ( "trying for size of " + ss.str() + "B" ) {
                 std::vector<uint8_t> buffer(s);
-                SECTION ( "plain data" ) {
+                CATCH_SECTION ( "plain data" ) {
                     test_paste(bin, buffer);
                 }
-                SECTION ( "AES encrypted data" ) {
+                CATCH_SECTION ( "AES encrypted data" ) {
                     test_paste_encrypted(bin, buffer);
                 }
             }
@@ -101,49 +101,50 @@ TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
     }
 }
 
-TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste_uri]") {
+CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste_uri]") {
     PirateBinTester pt;
     const std::string CODE = random_code();
     std::string pin_upper {CODE.begin(), CODE.end()};
     std::transform(pin_upper.begin(), pin_upper.end(), pin_upper.begin(), ::toupper);
 
-    SECTION ( "good pins" ) {
+    CATCH_SECTION ( "good pins" ) {
         auto gc1 = "dpaste:"+CODE;
         auto gc2 = CODE;
-        REQUIRE ( pt.code_from_dpaste_uri(gc1) == CODE );
-        REQUIRE ( pt.code_from_dpaste_uri(gc2) == CODE );
+        CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc1) == CODE );
+        CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc2) == CODE );
 
-        SECTION ( "good pin (upper case)" ) {
+        CATCH_SECTION ( "good pin (upper case)" ) {
             auto gc3 = "dpaste:"+pin_upper;
             auto gc4 = pin_upper;
 
-            REQUIRE ( pt.code_from_dpaste_uri(gc3) == pin_upper );
-            REQUIRE ( pt.code_from_dpaste_uri(gc4) == pin_upper );
+            CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc3) == pin_upper );
+            CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc4) == pin_upper );
         }
     }
-    SECTION ( "bad pins" ) {
+    CATCH_SECTION ( "bad pins" ) {
         std::string bc1 = "DPASTE:"+CODE;
         std::string bc2 = "DPaste:"+CODE;
-        REQUIRE ( pt.code_from_dpaste_uri(bc1) != CODE );
-        REQUIRE ( pt.code_from_dpaste_uri(bc2) != CODE );
+        std::string gc3 = "dpaste:" + CODE + std::string {10};
+        CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc1) != CODE );
+        CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc2) != CODE );
 
-        SECTION ( "bad pins (upper case)" ) {
+        CATCH_SECTION ( "bad pins (upper case)" ) {
             auto bc3 = "DPASTE:"+pin_upper;
             auto bc4 = "DPaste:"+pin_upper;
 
-            REQUIRE ( pt.code_from_dpaste_uri(bc3) != pin_upper );
-            REQUIRE ( pt.code_from_dpaste_uri(bc4) != pin_upper );
+            CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc3) != pin_upper );
+            CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc4) != pin_upper );
         }
     }
 }
 
-TEST_CASE("Bin conversion of stringstream to vector", "[Bin][data_from_stream]") {
+CATCH_TEST_CASE("Bin conversion of stringstream to vector", "[Bin][data_from_stream]") {
     PirateBinTester pt;
 
     const std::string DATA = "SOME DATA";
     std::stringstream ss(DATA);
     std::vector<uint8_t> d {DATA.begin(), DATA.end()};
-    REQUIRE ( pt.data_from_stream(ss, DATA.size()) == d );
+    CATCH_REQUIRE ( pt.data_from_stream(ss, DATA.size()) == d );
 }
 
 } /* tests */

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -167,6 +167,14 @@ CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_
     }
 }
 
+CATCH_TEST_CASE("Bin conversion to hex string from int", "[Bin][hexStrFromInt]") {
+    using pbt = PirateBinTester;
+    CATCH_REQUIRE ( pbt::hexStrFromInt(255, 2) == "ff" );
+    CATCH_REQUIRE ( pbt::hexStrFromInt(121, 2) == "79" );
+    CATCH_REQUIRE ( pbt::hexStrFromInt(0, 2) == "00" );
+}
+
+
 CATCH_TEST_CASE("Bin conversion of stringstream to vector", "[Bin][data_from_stream]") {
     PirateBinTester pt;
 

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -124,7 +124,6 @@ CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_
     CATCH_SECTION ( "bad pins" ) {
         std::string bc1 = "DPASTE:"+CODE;
         std::string bc2 = "DPaste:"+CODE;
-        std::string gc3 = "dpaste:" + CODE + std::string {10};
         CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc1) != CODE );
         CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc2) != CODE );
 

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -46,7 +46,7 @@ public:
         return Bin::parse_code_info(uri);
     }
 
-    std::string code_from_dpaste_uri(const std::string& uri) const {
+    static std::string code_from_dpaste_uri(const std::string& uri) {
         return Bin::code_from_dpaste_uri(uri);
     }
 
@@ -111,7 +111,6 @@ CATCH_TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
 
 CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste_uri][parse_code_info]") {
     using pbt = PirateBinTester;
-    PirateBinTester pt;
     const uint32_t NPACKETS     = (uint32_t)random_number() % 256;
     const std::string NPACKETSS = pbt::hexStrFromInt(NPACKETS, 2);
     const std::string LCODE     = random_code();
@@ -132,18 +131,18 @@ CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_
         auto gc1 = "dpaste:"+CODE;
         auto gc2 = CODE;
         auto gc3 = "dpaste:"+CODE+PWD;
-        CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc1) == CODE );
-        CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc2) == CODE );
-        CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc3) == CODE+PWD );
+        CATCH_REQUIRE ( pbt::code_from_dpaste_uri(gc1) == CODE );
+        CATCH_REQUIRE ( pbt::code_from_dpaste_uri(gc2) == CODE );
+        CATCH_REQUIRE ( pbt::code_from_dpaste_uri(gc3) == CODE+PWD );
 
         CATCH_SECTION ( "good pin (upper case)" ) {
             auto gc4 = "dpaste:"+pin_upper;
             auto gc5 = pin_upper;
             auto gc6 = "dpaste:"+pin_upper+PWD;
 
-            CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc4) == pin_upper );
-            CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc5) == pin_upper );
-            CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc6) == pin_upper+PWD );
+            CATCH_REQUIRE ( pbt::code_from_dpaste_uri(gc4) == pin_upper );
+            CATCH_REQUIRE ( pbt::code_from_dpaste_uri(gc5) == pin_upper );
+            CATCH_REQUIRE ( pbt::code_from_dpaste_uri(gc6) == pin_upper+PWD );
         }
         CATCH_SECTION ( "testing Bin::parse_code_info" ) {
             test_code_parsing(CODE, "");
@@ -155,15 +154,15 @@ CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_
     CATCH_SECTION ( "bad pins" ) {
         std::string bc1 = "DPASTE:"+CODE;
         std::string bc2 = "DPaste:"+CODE;
-        CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc1) != CODE );
-        CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc2) != CODE );
+        CATCH_REQUIRE ( pbt::code_from_dpaste_uri(bc1) != CODE );
+        CATCH_REQUIRE ( pbt::code_from_dpaste_uri(bc2) != CODE );
 
         CATCH_SECTION ( "bad pins (upper case)" ) {
             auto bc3 = "DPASTE:"+pin_upper;
             auto bc4 = "DPaste:"+pin_upper;
 
-            CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc3) != pin_upper );
-            CATCH_REQUIRE ( pt.code_from_dpaste_uri(bc4) != pin_upper );
+            CATCH_REQUIRE ( pbt::code_from_dpaste_uri(bc3) != pin_upper );
+            CATCH_REQUIRE ( pbt::code_from_dpaste_uri(bc4) != pin_upper );
         }
     }
 }

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -38,6 +38,10 @@ public:
 
     static std::string dpaste_uri_prefix() { return Bin::DPASTE_URI_PREFIX; }
 
+    static std::string hexStrFromInt(uint32_t i, size_t len) {
+        return Bin::hexStrFromInt(i, len);
+    }
+
     std::string code_from_dpaste_uri(const std::string& uri) const {
         return Bin::code_from_dpaste_uri(uri);
     }
@@ -103,7 +107,10 @@ CATCH_TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
 
 CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste_uri]") {
     PirateBinTester pt;
-    const std::string CODE = random_code();
+    const uint32_t NPACKETS     = (uint32_t)random_number() % 256;
+    const std::string NPACKETSS = pbt::hexStrFromInt(NPACKETS, 2);
+    const std::string LCODE     = random_code();
+    const std::string CODE      = LCODE + NPACKETSS;
     const std::string PWD       = random_code();
     std::string pin_upper {CODE.begin(), CODE.end()};
     std::transform(pin_upper.begin(), pin_upper.end(), pin_upper.begin(), ::toupper);

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -77,15 +77,15 @@ TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
 
 TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste_uri]") {
     PirateBinTester pt;
-    const std::string PIN = random_pin();
-    std::string pin_upper {PIN.begin(), PIN.end()};
+    const std::string CODE = random_code();
+    std::string pin_upper {CODE.begin(), CODE.end()};
     std::transform(pin_upper.begin(), pin_upper.end(), pin_upper.begin(), ::toupper);
 
     SECTION ( "good pins" ) {
-        auto gc1 = "dpaste:"+PIN;
-        auto gc2 = PIN;
-        REQUIRE ( pt.code_from_dpaste_uri(gc1) == PIN );
-        REQUIRE ( pt.code_from_dpaste_uri(gc2) == PIN );
+        auto gc1 = "dpaste:"+CODE;
+        auto gc2 = CODE;
+        REQUIRE ( pt.code_from_dpaste_uri(gc1) == CODE );
+        REQUIRE ( pt.code_from_dpaste_uri(gc2) == CODE );
 
         SECTION ( "good pin (upper case)" ) {
             auto gc3 = "dpaste:"+pin_upper;
@@ -96,10 +96,10 @@ TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste
         }
     }
     SECTION ( "bad pins" ) {
-        std::string bc1 = "DPASTE:"+PIN;
-        std::string bc2 = "DPaste:"+PIN;
-        REQUIRE ( pt.code_from_dpaste_uri(bc1) != PIN );
-        REQUIRE ( pt.code_from_dpaste_uri(bc2) != PIN );
+        std::string bc1 = "DPASTE:"+CODE;
+        std::string bc2 = "DPaste:"+CODE;
+        REQUIRE ( pt.code_from_dpaste_uri(bc1) != CODE );
+        REQUIRE ( pt.code_from_dpaste_uri(bc2) != CODE );
 
         SECTION ( "bad pins (upper case)" ) {
             auto bc3 = "DPASTE:"+pin_upper;

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -104,21 +104,26 @@ CATCH_TEST_CASE("Bin get/paste on DHT", "[Bin][get][paste]") {
 CATCH_TEST_CASE("Bin parsing of uri code ([dpaste:]XXXXXXXX)", "[Bin][code_from_dpaste_uri]") {
     PirateBinTester pt;
     const std::string CODE = random_code();
+    const std::string PWD       = random_code();
     std::string pin_upper {CODE.begin(), CODE.end()};
     std::transform(pin_upper.begin(), pin_upper.end(), pin_upper.begin(), ::toupper);
 
     CATCH_SECTION ( "good pins" ) {
         auto gc1 = "dpaste:"+CODE;
         auto gc2 = CODE;
+        auto gc3 = "dpaste:"+CODE+PWD;
         CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc1) == CODE );
         CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc2) == CODE );
+        CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc3) == CODE+PWD );
 
         CATCH_SECTION ( "good pin (upper case)" ) {
             auto gc3 = "dpaste:"+pin_upper;
             auto gc4 = pin_upper;
+            auto gc6 = "dpaste:"+pin_upper+PWD;
 
             CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc3) == pin_upper );
             CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc4) == pin_upper );
+            CATCH_REQUIRE ( pt.code_from_dpaste_uri(gc6) == pin_upper+PWD );
         }
     }
     CATCH_SECTION ( "bad pins" ) {

--- a/tests/bin.cpp
+++ b/tests/bin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Simon Désaulniers
+ * Copyright © 2018-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/tests/catch.h
+++ b/tests/catch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Simon Désaulniers
+ * Copyright © 2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.
@@ -18,33 +18,11 @@
  * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <memory>
+#pragma once
 
-#include "cipher.h"
-#include "aescrypto.h"
+#define CATCH_CONFIG_PREFIX_ALL 0
 
-#include "catch.h"
+#include <catch.hpp>
 
-namespace dpaste {
-namespace tests {
-
-CATCH_TEST_CASE("AES process plain/cipher text", "[AES][processPlainText][processCipherText]") {
-    crypto::AES aes {};
-    std::vector<uint8_t> data {0,1,2,3,4};
-    auto pwd = "this_is_a_really_good_pwd";
-    auto p = std::make_shared<crypto::Parameters>();
-    auto pp = p;
-    p->emplace<crypto::AESParameters>(pwd);
-
-    auto ct = aes.processPlainText(data, std::move(p));
-    CATCH_REQUIRE ( not ct.empty() );
-
-    auto pt = aes.processCipherText(ct, std::move(pp));
-    CATCH_REQUIRE ( pt == data );
-}
-
-} /* tests */
-} /* dpaste */
-
-/* vim: set ts=4 sw=4 tw=120 et :*/
+/* vim: set sts=4 ts=4 sw=4 tw=120 et :*/
 

--- a/tests/conf.cpp
+++ b/tests/conf.cpp
@@ -18,37 +18,37 @@
  * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <catch.hpp>
-
 #include "conf.h"
+
+#include "catch.h"
 
 namespace dpaste {
 namespace tests {
 
 const std::string CONFIG_FILE_PATH_PREFIX = "./tests/misc/dpaste.conf";
 
-TEST_CASE("ConfigurationFile loading/parsing (./misc/dpaste.conf)", "[ConfigurationFile][get][load]") {
-    SECTION ( "Well-formed file" ) {
+CATCH_TEST_CASE("ConfigurationFile loading/parsing (./misc/dpaste.conf)", "[ConfigurationFile][get][load]") {
+    CATCH_SECTION ( "Well-formed file" ) {
         conf::ConfigurationFile f(CONFIG_FILE_PATH_PREFIX+".1");
-        REQUIRE ( f.load() == 0 );
+        CATCH_REQUIRE ( f.load() == 0 );
 
         auto c = f.getConfiguration();
-        REQUIRE ( c.at("host") ==  "192.168.1.100" );
-        REQUIRE ( c.at("port") ==  "6500" );
+        CATCH_REQUIRE ( c.at("host") ==  "192.168.1.100" );
+        CATCH_REQUIRE ( c.at("port") ==  "6500" );
     }
-    SECTION ( "Malformed file (bad host)" ) {
+    CATCH_SECTION ( "Malformed file (bad host)" ) {
         conf::ConfigurationFile f(CONFIG_FILE_PATH_PREFIX+".2");
-        REQUIRE ( f.load() == 0 );
+        CATCH_REQUIRE ( f.load() == 0 );
 
         auto c = f.getConfiguration();
-        REQUIRE ( c.at("host") ==  "127.0.0.1" ); /* the default         */
-        REQUIRE ( c.at("port") ==  "6500" );      /* recovered from file */
+        CATCH_REQUIRE ( c.at("host") ==  "127.0.0.1" ); /* the default         */
+        CATCH_REQUIRE ( c.at("port") ==  "6500" );      /* recovered from file */
     }
-    SECTION ( "File not found" ) {
+    CATCH_SECTION ( "File not found" ) {
         conf::ConfigurationFile f("/dpaste.conf"); /* This should not work on
                                                       any computer owned by a
                                                       sane person */
-        REQUIRE ( f.load() == 1 );
+        CATCH_REQUIRE ( f.load() == 1 );
     }
 }
 

--- a/tests/conf.cpp
+++ b/tests/conf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Simon Désaulniers
+ * Copyright © 2018-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -38,7 +38,7 @@ public:
 TEST_CASE("Node get/paste on DHT", "[Node][get][paste]") {
     PirateNodeTester pt;
 
-    const std::string PIN = random_pin();
+    const std::string PIN = random_code();
     std::vector<uint8_t> data = {0, 1, 2, 3, 4};
     dpaste::Node node {};
     node.run();

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -18,7 +18,7 @@
  * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <catch.hpp>
+#include "catch.h"
 
 #include "tests.h"
 #include "node.h"
@@ -35,7 +35,7 @@ public:
     bool is_running(const dpaste::Node& n) const { return n.running_; }
 };
 
-TEST_CASE("Node get/paste on DHT", "[Node][get][paste]") {
+CATCH_TEST_CASE("Node get/paste on DHT", "[Node][get][paste]") {
     PirateNodeTester pt;
 
     const std::string PIN = random_code();
@@ -43,17 +43,17 @@ TEST_CASE("Node get/paste on DHT", "[Node][get][paste]") {
     dpaste::Node node {};
     node.run();
 
-    SECTION ( "pasting data {0,1,2,3,4}" ) {
-        REQUIRE ( node.paste(PIN, std::vector<uint8_t> {data}) );
+    CATCH_SECTION ( "pasting data {0,1,2,3,4}" ) {
+        CATCH_REQUIRE ( node.paste(PIN, std::vector<uint8_t> {data}) );
 
-        SECTION ( "getting pasted blob back from the DHT" ) {
+        CATCH_SECTION ( "getting pasted blob back from the DHT" ) {
             auto rd = node.get(PIN);
-            REQUIRE ( data == rd.front() );
+            CATCH_REQUIRE ( data == rd.front() );
         }
     }
 
     node.stop();
-    REQUIRE ( not pt.is_running(node) );
+    CATCH_REQUIRE ( not pt.is_running(node) );
 }
 
 } /* tests */

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Simon Désaulniers
+ * Copyright © 2018-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -44,7 +44,7 @@ int random_number() {
     return dist(rand_);
 }
 
-std::string random_pin() {
+std::string random_code() {
     const auto i = random_number();
     std::stringstream ss;
     ss << std::hex << i;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Simon Désaulniers
+ * Copyright © 2018-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -22,7 +22,7 @@ namespace dpaste {
 namespace tests {
 
 int random_number();
-std::string random_pin();
+std::string random_code();
 
 } /* tests */
 } /* dpaste */

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Simon Désaulniers
+ * Copyright © 2018-2020 Simon Désaulniers
  * Author: Simon Désaulniers <sim.desaulniers@gmail.com>
  *
  * This file is part of dpaste.

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -18,6 +18,8 @@
  * along with dpaste.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <string>
+
 namespace dpaste {
 namespace tests {
 


### PR DESCRIPTION
This introduces a new feature: **packet splitting**. This effectively splits files bigger than the maximum size allowed by OpenDHT (which is around 56 KiB) and spreads the pieces in packets published evenly on the DHT. Let's consider the following regarding this new approach:

* The paste code (used for sharing the pasted blob) now incorporates a new field for encoding the number of packets the file was split into. The format is now described as follows:

        LOCATION_CODE + NPACKETS
        LOCATION_CODE + NPACKETS + PWD
        "dpaste:" + LOCATION_CODE + NPACKETS
        "dpaste:" + LOCATION_CODE + NPACKETS + PWD

  This suggests 4 possible code formats. The size for each field is given in the following table:

  | Data            | Size    | Size (in characters) |
  |-----------------|---------|----------------------|
  | `LOCATION_CODE` | 32 bits | 8 hex chars          |
  | `NPACKETS`      | 8 bits  | 2 hex chars          |
  | `PWD`           | 32 bits | 8 hex chars          |

  For now this change is not backward compatible with prior version such as 0.3.3 or even the latest master.

  * [ ] implement backward compatibility by parsing the field `NPACKETS` or not.

  While new versions of dpaste will support old code formats, it obviously won't be magically the case for the other way around except for values of size less than 56KiB (non splitted values) and without AES encryption.
* As said above, the file is split in packets spread on evenly on the DHT. While publishing all packets around a same area on the DHT could improve network performance (subsequent requests would resolve faster after the first one), OpenDHT's rate limiting could interfere with the capacity of a node to publish the whole file it looks to publish.
* The time issue mentioned above is in part due to the multiple gets/puts done sequentially inside Bin.
  * [ ] Parallelize the multiple get/put operations.

Tests have also been added to verify good behaviour of different new functions.

**N.B**: OpenDHT advertises 64KiB as its maximum value size, but it doesn't take serializing into account so the effective maximum size is rather around 56 KiB.