### PR TITLE
http_client: appending nlohmann parent directory in include statement

### DIFF
--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -25,7 +25,7 @@
 #include <curlpp/Options.hpp>
 #include <curlpp/Exception.hpp>
 #include <curlpp/Infos.hpp>
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 #include <b64/decode.h>
 
 #include "http_client.h"


### PR DESCRIPTION
The parent directory was not present on Debian at the time, but according to the [content
of the package on the buster branch][filelist], the parent directory is now present. This is
the reason why the include statement was only on `json.hpp`, but I'm realizing that it was
a distribution issue on Debian's side and I should have used `nlohmann/json.hpp` instead.

[filelist]: https://packages.debian.org/buster/all/nlohmann-json-dev/filelist