### PR TITLE
Align libcurlpp dependency with latest upstream master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Milis Linux:   mps kur dpaste  (https://github.com/milisarge/malfs-milis/blob/ma
 - [msgpack-c](https://github.com/msgpack/msgpack-c)
 - [gpgmepp](https://github.com/KDE/gpgmepp)
 - [json.hpp](https://github.com/nlohmann/json) (required version for CMake: 2.1.1)
-- [cURLpp](https://github.com/jpbarrette/curlpp) (minimal version: 0.8.1)
+- [cURLpp](https://github.com/jpbarrette/curlpp) (0.8.1 is known to fail to build. Use master branch of curlpp repo until a new release is made)
 - [glibmm](https://github.com/GNOME/glibmm)
 - [libb64](http://libb64.sourceforge.net/)
 - Getopt

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <fstream>
+#include <cstdint>
 
 #include <curlpp/cURLpp.hpp>
 #include <curlpp/Easy.hpp>


### PR DESCRIPTION
This fixes compilation issues with latest libcurlpp which previously failed with:

```
In file included from /usr/include/curlpp/Infos.hpp:29,
                 from http_client.cpp:26:
/usr/include/curlpp/Info.hpp:44:33: error: « uint32_t » n'a pas été déclaré
   44 |         template<CURLINFO info, uint32_t type_mask = (info& CURLINFO_TYPEMASK)>
      |                                 ^~~~~~~~
/usr/include/curlpp/Info.hpp:31:1: note: « uint32_t » est défini dans l'en-tête « <cstdint> » ; ceci peut probablement être corrigé en ajoutant « #include <cstdint> »
   30 | #include "Easy.hpp"
  +++ |+#include <cstdint>
   31 |
/usr/include/curlpp/Info.hpp:103:68: error: l'argument 2 du patron est invalide
  103 |         template<CURLINFO info, typename T = typename InfoType<info>::Type>
```